### PR TITLE
Update tg_notify to work with the latest output format

### DIFF
--- a/tg_notify.sh
+++ b/tg_notify.sh
@@ -9,26 +9,33 @@ TG_TOKEN=\"YOUR TELEGRAM TOKEN\"
 TG_CHAT_ID=\"YOUR TELEGRAM CHAT ID\"
 
 CONFIG_URL=\$(docker compose -f /root/db1000n/examples/docker/static-docker-compose.yml logs --tail=100 | grep -o \"https://raw.*json\" | uniq | tail -1)
+TOTAL=\$(docker compose -f /root/db1000n/examples/docker/static-docker-compose.yml logs | grep -o \"Total.*\" | tail -n 1 | sed -e 's/[^[:digit:].-MB]/|/g' | tr -s '|' ' ')
 
-message=\"Host: \$(hostname)\"
-message+=\"%0A\"
-message+=\$(docker compose -f /root/db1000n/examples/docker/static-docker-compose.yml logs | grep -o \"Current country: [.a-zA-Z]*\" | tr -s ' ' | tail -n 1)
-message+=\"%0A\"
-message+=\$(docker compose -f /root/db1000n/examples/docker/static-docker-compose.yml logs | grep -o \"Generated.*|\" | sed 's/ ] /: /' | sed 's/ |//' | tr -s ' ' | tail -n 1)
-message+=\"%0A\"
-message+=\$(docker compose -f /root/db1000n/examples/docker/static-docker-compose.yml logs | grep -o \"Received.*|\" | sed 's/ ] /: /' | sed 's/ |//' | tr -s ' ' | tail -n 1)
-message+=\"%0A\"
-message+=\$(docker compose -f /root/db1000n/examples/docker/static-docker-compose.yml logs | grep -o \"Response rate.*\" | sed 's/ ] /: /' | tr -s ' ' | tail -n 1)
-message+=\"%0A\"
-message+=\"Targets:\"
-message+=\"%0A\"
-message+=\$(curl -s \$CONFIG_URL | jq '.jobs[].args | select(.request != null) | .request.path' | sed 's/\"http.*\/\///' | sed 's/\"//' | sed 's/\/.*//g' | sort | uniq)
+ATTEMPTED=\$(echo \$TOTAL | cut -d' ' -f 1)
+SENT=\$(echo \$TOTAL | cut -d' ' -f 2)
+RECEIVED=\$(echo \$TOTAL | cut -d' ' -f 3)
+DATA=\$(echo \$TOTAL | cut -d' ' -f 4,5)
+TARGETS=\$(curl -s \$CONFIG_URL | jq '.jobs[].args | select(.request != null) | .request.path' | sed 's/\"http.*\/\///' | sed 's/\"//' | sed 's/\/.*//g' | sort | uniq)
 
+message=\"*Host*: \\\`\$(hostname)\\\`\"
+message+=\"%0A\"
+message+=\"*Requests attempted*: \\\`\$ATTEMPTED\\\`\"
+message+=\"%0A\"
+message+=\"*Requests sent*: \\\`\$SENT\\\`\"
+message+=\"%0A\"
+message+=\"*Responses received*: \\\`\$RECEIVED\\\`\"
+message+=\"%0A\"
+message+=\"*Data sent*: \\\`\$DATA\\\`\"
+message+=\"%0A\"
+message+=\"*Targets*:\"
+message+=\"%0A\"
+message+=\$TARGETS
 
 curl -s --data \"text=\${message}\" \
         --data \"chat_id=\$TG_CHAT_ID\" \
+        --data \"parse_mode=markdown\" \
         \"https://api.telegram.org/bot\${TG_TOKEN}/sendMessage\"
-" >> /root/tg.sh
+" > /root/tg.sh
 
 chmod u+x /root/tg.sh
 


### PR DESCRIPTION
Fixes #2. 

**To update:**
1. Login to your server
2. Find you current `TG_TOKEN` and `TG_CHAT_ID` values in `/root/tg.sh` file and save it somewhere
3. Copy lines 3-38 in tg_notify.sh https://github.com/sadviq99/db1000n-setup/blob/d33aeb5d1c3c25e19fffe6bfca08cb60d56d8768/tg_notify.sh#L3-L38
4. Paste it into the terminal on your server
5. Open `/root/tg.sh` file and replace `TG_TOKEN` and `TG_CHAT_ID` with your values
6. Execute `/bin/bash /root/tg.sh` to make sure that everything is working fine, or just wait for the new notification

The new output will be like below.

For mobile: 
<img width="432" alt="Снимок экрана 2022-04-19 в 23 21 00" src="https://user-images.githubusercontent.com/102911721/164103977-fce37585-fd92-4257-8334-3e6fc41fd6d5.png">

For PC:
<img width="310" alt="Снимок экрана 2022-04-19 в 23 18 03" src="https://user-images.githubusercontent.com/102911721/164104024-0e104bbd-0c22-4c52-a764-80ff34dbb087.png">
