### PR TITLE
Fix notifications after db1000n output update (again)

### DIFF
--- a/tg_notify.sh
+++ b/tg_notify.sh
@@ -8,28 +8,13 @@ set -x
 TG_TOKEN=\"YOUR TELEGRAM TOKEN\"
 TG_CHAT_ID=\"YOUR TELEGRAM CHAT ID\"
 
-CONFIG_URL=\$(docker compose -f /root/db1000n/examples/docker/static-docker-compose.yml logs --tail=100 | grep -o \"https://raw.*json\" | uniq | tail -1)
-TOTAL=\$(docker compose -f /root/db1000n/examples/docker/static-docker-compose.yml logs | grep -o \"Total.*\" | tail -n 1 | sed -e 's/[^[:digit:].-MB]/|/g' | tr -s '|' ' ')
-COUNTRY=$(docker compose -f /root/db1000n/examples/docker/static-docker-compose.yml logs --no-log-prefix | grep  \"country*\" | tail -n 1 | jq -r '.country')
-
-ATTEMPTED=\$(echo \$TOTAL | cut -d' ' -f 1)
-SENT=\$(echo \$TOTAL | cut -d' ' -f 2)
-RECEIVED=\$(echo \$TOTAL | cut -d' ' -f 3)
-DATA=\$(echo \$TOTAL | cut -d' ' -f 4,5)
-TARGETS=\$(curl -s \$CONFIG_URL | jq '.jobs[].args | select(.request != null) | .request.path' | sed 's/\"http.*\/\///' | sed 's/\"//' | sed 's/\/.*//g' | sort | uniq)
+TARGETS=\$(docker compose -f /root/db1000n/examples/docker/static-docker-compose.yml logs --tail=1000 | grep 'stats' | grep 'target.*://.*' | cut -d '|' -f 2 | jq -r '. | \"\(.target) \`(\(.requests_sent)/\(.responses_received), \(.bytes_sent/1000000)MB)\`\"' | sed 's/.*\/\///' | awk -F' ' '!_[\$1]++' | sed -E 's/([0-9]+\.[0-9]{1,2})[^ ]*MB/\1MB/g' | sort -n -r -k3)
+COUNTRY=\$(docker compose -f /root/db1000n/examples/docker/static-docker-compose.yml logs --no-log-prefix | grep  'country*' | tail -n 1 | jq -r '.country')
 
 message=\"*Host*: \\\`\$(hostname)\\\`\"
 message+=\"%0A\"
-message+=\"*Requests attempted*: \\\`\$ATTEMPTED\\\`\"
-message+=\"%0A\"
-message+=\"*Requests sent*: \\\`\$SENT\\\`\"
-message+=\"%0A\"
-message+=\"*Responses received*: \\\`\$RECEIVED\\\`\"
-message+=\"%0A\"
-message+=\"*Data sent*: \\\`\$DATA\\\`\"
-message+=\"%0A\"
 message+=\"*VPN location*: \\\`\$COUNTRY\\\`\"
-message+="%0A"
+message+=\"%0A\"
 message+=\"*Targets*:\"
 message+=\"%0A\"
 message+=\$TARGETS


### PR DESCRIPTION
After the db1000n update, the output format has been changed again. It is still possible to get the "total" statistic as a JSON line, but that worked 1/3 times for me, so I gave up on that, we can't rely on that. 
```
docker-programm-1  | {"level":"info","ts":1650813556.245873,"caller":"metrics/metrics.go:183","msg":"stats","target":"total","requests_attempted":13536,"requests_sent":1843,"responses_received":1843,"bytes_sent":314844}
```

An alternative solution was to show the stats for each target, I selected this way. To upgrade, do next:
1. Login to the console
2. Open /root/tg.sh file and some your TG token and chat id somewhere
3. Return back to the console
4. Copy and paste this content to the console, press Enter https://github.com/sadviq99/db1000n-setup/blob/4793297041c5e406f1d29629b83e271151b1f634/tg_notify.sh#L3-L26
5. Open /root/tg.sh and return back you TG token and chat id values

The next notification will look like below:
<img width="939" alt="img" src="https://user-images.githubusercontent.com/102911721/164998120-1e294d93-2408-4088-be62-493bf1aa229c.png">


