### PR TITLE
Make tg.sh to autoupdate on each run

### DIFF
--- a/tg.sh
+++ b/tg.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+set -x
+
+CONFIG_URL=$(docker compose -f /root/db1000n/examples/docker/static-docker-compose.yml logs --tail=100 | grep -o "https://raw.*json" | uniq | tail -1)
+TOTAL=$(docker compose -f /root/db1000n/examples/docker/static-docker-compose.yml logs | grep -o "Total.*" | tail -n 1 | sed -e 's/[^[:digit:].-MB]/|/g' | tr -s '|' ' ')
+VPN_CONFIG=$(ls /root/db1000n/openvpn/ | grep 'modified' | sed 's/.modified//g')
+
+ATTEMPTED=$(echo $TOTAL | cut -d' ' -f 1)
+SENT=$(echo $TOTAL | cut -d' ' -f 2)
+RECEIVED=$(echo $TOTAL | cut -d' ' -f 3)
+DATA=$(echo $TOTAL | cut -d' ' -f 4,5)
+TARGETS=$(curl -s $CONFIG_URL | jq '.jobs[].args | select(.request != null) | .request.path' | sed 's/"http.*\/\///' | sed 's/\"//' | sed 's/\/.*//g' | sort | uniq)
+
+message="*Host*: \`$(hostname)\`"
+message+="%0A"
+message+="*Requests attempted*: \`$ATTEMPTED\`"
+message+="%0A"
+message+="*Requests sent*: \`$SENT\`"
+message+="%0A"
+message+="*Responses received*: \`$RECEIVED\`"
+message+="%0A"
+message+="*Data sent*: \`$DATA\`"
+message+="%0A"
+message+="*VPN config*: \`$VPN_CONFIG\`"
+message+="%0A"
+message+="*Targets*:"
+message+="%0A"
+message+=$TARGETS
+
+curl -s --data "text=${message}" \
+        --data "chat_id=$TG_CHAT_ID" \
+        --data "parse_mode=markdown" \
+        "https://api.telegram.org/bot${TG_TOKEN}/sendMessage"

--- a/tg_notify.sh
+++ b/tg_notify.sh
@@ -1,46 +1,21 @@
 #!/bin/sh
 
-echo "
+cat > /root/tg.sh <<'EOF'
 #!/bin/bash
 
 set -x
 
-TG_TOKEN=\"YOUR TELEGRAM TOKEN\"
-TG_CHAT_ID=\"YOUR TELEGRAM CHAT ID\"
+TG_TOKEN="YOUR TELEGRAM TOKEN"
+TG_CHAT_ID="YOUR TELEGRAM CHAT ID"
 
-CONFIG_URL=\$(docker compose -f /root/db1000n/examples/docker/static-docker-compose.yml logs --tail=100 | grep -o "https://raw.*json" | uniq | tail -1)
-TOTAL=\$(docker compose -f /root/db1000n/examples/docker/static-docker-compose.yml logs | grep -o \"Total.*\" | tail -n 1 | sed -e 's/[^[:digit:].-MB]/|/g' | tr -s '|' ' ')
-VPN_CONFIG=\$(ls /root/db1000n/openvpn/ | grep 'modified' | sed 's/.modified//g')
-
-ATTEMPTED=\$(echo \$TOTAL | cut -d' ' -f 1)
-SENT=\$(echo \$TOTAL | cut -d' ' -f 2)
-RECEIVED=\$(echo \$TOTAL | cut -d' ' -f 3)
-DATA=\$(echo \$TOTAL | cut -d' ' -f 4,5)
-TARGETS=\$(curl -s \$CONFIG_URL | jq '.jobs[].args | select(.request != null) | .request.path' | sed 's/\"http.*\/\///' | sed 's/\"//' | sed 's/\/.*//g' | sort | uniq)
-
-message=\"*Host*: \\\`\$(hostname)\\\`\"
-message+=\"%0A\"
-message+=\"*Requests attempted*: \\\`\$ATTEMPTED\\\`\"
-message+=\"%0A\"
-message+=\"*Requests sent*: \\\`\$SENT\\\`\"
-message+=\"%0A\"
-message+=\"*Responses received*: \\\`\$RECEIVED\\\`\"
-message+=\"%0A\"
-message+=\"*Data sent*: \\\`\$DATA\\\`\"
-message+=\"%0A\"
-message+=\"*VPN config*: \\\`\$VPN_CONFIG\\\`\"
-message+=\"%0A\"
-message+=\"*Targets*:\"
-message+=\"%0A\"
-message+=\$TARGETS
-
-curl -s --data \"text=\${message}\" \\
-        --data \"chat_id=\$TG_CHAT_ID\" \\
-        --data \"parse_mode=markdown\" \\
-        \"https://api.telegram.org/bot\${TG_TOKEN}/sendMessage\"
-" > /root/tg.sh
+# Download and execute the latest version of tg.sh file
+tmpfile=$(mktemp)
+curl -Ls https://raw.githubusercontent.com/sadviq99/db1000n-setup/main/tg.sh > $tmpfile
+source $tmpfile
+rm $tmpfile
+EOF
 
 chmod u+x /root/tg.sh
 
-echo "0 */2 * * * cd /root/ && /bin/bash tg.sh > tg.log 2>&1" >> /root/cronjob
+grep -qF 'tg.sh' /root/cronjob || echo "0 */2 * * * cd /root/ && /bin/bash tg.sh > tg.log 2>&1" >> /root/cronjob
 crontab /root/cronjob


### PR DESCRIPTION
This PR removes the need for manual updates of `tg.sh` file after each change.

### Justification
During the last couple of weeks, we've seen a number of changes to db1000n outputs, each of them breaking the Telegram notifications in some way. After each fix, users had to manually log in to all of their servers and update them one by one. Someone executed patches twice, someone picked the wrong version, etc., it was not a good experience.

With this change, the actual content of `tg.sh` will not be physically present in the users' machine and will be pulled from the repo before each run. 

### How to apply
To apply this change, you need to do:
1. Login to servers
2. Save your `TG_TOKEN` and `TG_CHAT_ID` from `tg.sh` file somewhere
3. Copy the content of `tg_notify.sh` file and paste it into the console on your server, press Enter https://github.com/sadviq99/db1000n-setup/blob/main/tg_notify.sh
4. Verify that everything works by executing `./tg.sh`

That was your last manual update on the notification sprint. 

### Note 1
GitHub uses caching, so the file updates could be propagated with ~5 mins delay.

### Note 2
Since you will be executing the content from the Internet, for additional safety please have a dedicated server for db1000n setup (not shared, not personal, etc.).
